### PR TITLE
feat: Define a password for a jupyter notebook and wait until running

### DIFF
--- a/exalsius/cli/commands/workspaces.py
+++ b/exalsius/cli/commands/workspaces.py
@@ -1,3 +1,4 @@
+import time
 from typing import Annotated
 
 import typer
@@ -99,6 +100,12 @@ def add_workspace(
         "-t",
         help='The type of the workspace to add. Can be "pod" or "jupyter". Default is "pod"',
     ),
+    jupyter_password: str = typer.Option(
+        None,
+        "--jupyter-password",
+        "-p",
+        help="The password for the Jupyter notebook",
+    ),
 ):
     console = Console(theme=custom_theme)
     service = WorkspacesService()
@@ -109,33 +116,65 @@ def add_workspace(
         typer.echo("No default cluster found")
         raise typer.Exit(1)
 
-    workspace_create_response, error = service.create_workspace(
-        cluster_id=active_cluster.id,
-        name=name,
-        gpu_count=gpu_count,
-        owner=owner,
-        workspace_type=workspace_type,
-    )
-    if error:
-        typer.echo(f"Error while creating workspace: {error}")
-        raise typer.Exit(1)
-
-    workspace_response, error = service.get_workspace(
-        workspace_create_response.workspace_id
-    )
-    if error:
-        display_manager.print_warning(
-            f"Error while reading workspace access info: {error}"
+    with console.status(
+        "[bold custom]Creating workspace...[/bold custom]",
+        spinner="bouncingBall",
+        spinner_style="custom",
+    ):
+        workspace_create_response, error = service.create_workspace(
+            cluster_id=active_cluster.id,
+            name=name,
+            gpu_count=gpu_count,
+            owner=owner,
+            workspace_type=workspace_type,
+            jupyter_password=jupyter_password,
         )
-        display_manager.print_warning(
-            "Try to run `exalsius workspaces show-access-info <workspace_id>` to get the access information"
-        )
-        raise typer.Exit(1)
+        if error:
+            display_manager.print_error(f"Error while creating workspace: {error}")
+            raise typer.Exit(1)
 
-    # TODO: Wait for the workspace to be ready
-    workspace: Workspace = workspace_response.workspace
-    display_manager.display_workspace_created(workspace)
-    display_manager.display_workspace_access_info(workspace)
+        # TODO: add a timeout to the service and operation
+        timeout = 120  # 2 minutes
+        polling_interval = 5  # 5 seconds
+        start_time = time.time()
+
+        while time.time() - start_time < timeout:
+            workspace_response, error = service.get_workspace(
+                workspace_create_response.workspace_id
+            )
+            if error:
+                display_manager.print_warning(
+                    f"Error while reading workspace status: {error}"
+                )
+                raise typer.Exit(1)
+
+            workspace: Workspace = workspace_response.workspace
+            if workspace.workspace_status == "RUNNING":
+                # TODO: This handles backend-side edge case where the status is running but the access info is not available yet.
+                time.sleep(polling_interval)
+                workspace_response, error = service.get_workspace(
+                    workspace_create_response.workspace_id
+                )
+                if error:
+                    display_manager.print_warning(
+                        f"Error while reading workspace status: {error}"
+                    )
+                    raise typer.Exit(1)
+                break
+
+            if workspace.workspace_status == "FAILED":
+                display_manager.print_error("Workspace creation failed.")
+                raise typer.Exit(1)
+
+            time.sleep(polling_interval)
+        else:
+            display_manager.print_error(
+                "Workspace did not become active in time. Please check the status manually."
+            )
+            raise typer.Exit(1)
+
+        display_manager.display_workspace_created(workspace)
+        display_manager.display_workspace_access_info(workspace)
 
 
 @app.command("show-access-info")

--- a/exalsius/core/operations/workspaces_operations.py
+++ b/exalsius/core/operations/workspaces_operations.py
@@ -128,6 +128,7 @@ class CreateWorkspaceJupyterOperation(CreateWorkspaceOperation):
         name: str,
         owner: str,
         gpu_count: int,
+        jupyter_password: Optional[str] = None,
     ):
         template = WorkspaceTemplate(
             name="jupyter-notebook-template",
@@ -136,6 +137,8 @@ class CreateWorkspaceJupyterOperation(CreateWorkspaceOperation):
                 "deploymentImage": "tensorflow/tensorflow:2.18.0-gpu-jupyter",
             },
         )
+        if jupyter_password:
+            template.variables["notebookPassword"] = jupyter_password
         super().__init__(api_client, cluster_id, name, template, owner, gpu_count)
 
 

--- a/exalsius/core/services/workspaces_services.py
+++ b/exalsius/core/services/workspaces_services.py
@@ -41,10 +41,11 @@ class WorkspacesService(BaseService):
         gpu_count: int,
         owner: str,
         workspace_type: WorkspaceType,
+        jupyter_password: Optional[str] = None,
     ) -> Tuple[WorkspaceCreateResponse, Optional[str]]:
         if workspace_type == WorkspaceType.JUPYTER:
             operation = CreateWorkspaceJupyterOperation(
-                self.api_client, cluster_id, name, owner, gpu_count
+                self.api_client, cluster_id, name, owner, gpu_count, jupyter_password
             )
         elif workspace_type == WorkspaceType.POD:
             operation = CreateWorkspacePodOperation(


### PR DESCRIPTION
## Description

This PR fixes #

Added option to define a password for a jupyter notebook. 
The workspace add command will  wait until the workspace it RUNNING. 
Static timeout timer is defined.