### PR TITLE
fix(marimo, jupyter): change duplicate -p flag to -s for storage

### DIFF
--- a/exalsius/workspaces/jupyter/cli.py
+++ b/exalsius/workspaces/jupyter/cli.py
@@ -83,7 +83,7 @@ def deploy_jupyter_workspace(
     pvc_storage_gb: PositiveInt = typer.Option(
         50,
         "--pvc-storage-gb",
-        "-p",
+        "-s",
         help="The amount of PVC storage in GB to add to the workspace",
     ),
     ephemeral_storage_gb: PositiveInt = typer.Option(

--- a/exalsius/workspaces/marimo/cli.py
+++ b/exalsius/workspaces/marimo/cli.py
@@ -83,7 +83,7 @@ def deploy_marimo_workspace(
     pvc_storage_gb: PositiveInt = typer.Option(
         50,
         "--pvc-storage-gb",
-        "-p",
+        "-s",
         help="The amount of PVC storage in GB to add to the workspace",
     ),
     ephemeral_storage_gb: PositiveInt = typer.Option(


### PR DESCRIPTION
## Description

This PR changes the flag for `pvc_storage_gb` from `-p` to `-s` to prevent conflicts with the `marimo/jupyter_password` option.

## Notes for Reviewers

<!-- 
## PR Title Format (Conventional Commits)

Please use one of the following prefixes in your PR title (the scope is optional):

- `feat(scope): ...` – New features or significant enhancements
- `fix(scope): ...` – Bug fixes
- `docs(scope): ...` – Documentation changes
- `refactor(scope): ...` – Code changes that neither fix bugs nor add features
- `chore(scope): ...` – Maintenance tasks, dependency updates, etc.
- `test(scope): ...` – Adding or modifying tests
- `ci(scope): ...` – Changes to CI configuration files and scripts

**Example:** `feat(auth): add OAuth2 login support`

Please also aim to use Conventional Commits for your individual commits, or squash your commits before merging.  
The **CHANGELOG is automatically generated** based on `feat:` and `fix:` messages.

## Multiple Contributors?

If this PR includes commits from multiple authors and you're going to squash-merge it, please consider adding  
`Co-authored-by:` lines to the final squash commit message to give proper credit.

Example:

```
Co-authored-by: Alice <alice@example.com>
Co-authored-by: Bob <bob@example.com>
```

More information: Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
-->