### PR TITLE
fix: add diloco default_config to site-packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,10 @@ dependencies = [
 
 [tool.setuptools.packages.find]
 where = ["."]
-include = ["exalsius*"] 
+include = ["exalsius*"]
+
+[tool.setuptools.package-data]
+"exalsius" = ["workspaces/**/*.yml", "workspaces/**/*.yaml"]
 
 [project.scripts]
 exls = "exalsius.app:app" 


### PR DESCRIPTION
## Description

By adding the following code, the  default_config.yml gets included in the site-packages. If this is not done, running` pip install git+https://github.com/exalsius/exalsius-cli.git@main` will exclude the config and the deployment of the workspace will show the following error .venv/lib/python3.12/site-packages/exalsius/workspaces/diloco/default_config.yml' does not exist