### PR TITLE
feat(auth): add get-token command for scripting

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ Here are some of the core commands to get you started:
 - **`exls workspaces`**: Manage workspaces on your clusters.
   - `exls workspaces deploy jupyter <cluster-id>`: Deploy a Jupyter workspace on a cluster.
   - `exls workspaces list <cluster-id>`: List workspaces on a cluster.
+- **`exls get-token`**: Print your access (bearer) token for use in scripts that call the exalsius API. The token is refreshed automatically if expired.
+  - `curl -H "Authorization: Bearer $(exls get-token)" https://api.exalsius.ai/...`
+  - `exls get-token --format json`: Emit `{"access_token": "<token>"}` instead of the bare token.
 
 For more details on each command, you can use the `--help` flag, for example `exls clusters --help`.
 

--- a/exls/app.py
+++ b/exls/app.py
@@ -7,7 +7,7 @@ import typer
 from exls import config as cli_config
 from exls.auth.adapters.bundle import AuthBundle
 from exls.auth.adapters.ui.display.display import IOAuthFacade
-from exls.auth.app import login, logout
+from exls.auth.app import get_token, login, logout
 from exls.auth.core.domain import AuthSession
 from exls.auth.core.service import AuthService, NotLoggedInWarning
 from exls.clusters.app import clusters_app
@@ -24,7 +24,7 @@ from exls.shared.core.exceptions import ServiceError
 from exls.state import AppState
 from exls.workspaces.app import workspaces_app
 
-NON_AUTH_COMMANDS = ["login", "logout"]
+NON_AUTH_COMMANDS = ["login", "logout", "get-token"]
 
 
 def _get_bundle(ctx: typer.Context) -> AuthBundle:
@@ -38,6 +38,7 @@ app = typer.Typer()
 # use them without a subcommand.
 app.command()(login)
 app.command()(logout)
+app.command()(get_token)
 
 
 app.add_typer(

--- a/exls/auth/app.py
+++ b/exls/auth/app.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from typing import Optional
 
@@ -126,3 +127,37 @@ def logout(ctx: typer.Context):
     io_facade.display_success_message(
         "Logged out successfully", output_format=bundle.message_output_format
     )
+
+
+def get_token(ctx: typer.Context):
+    """Print the current access token
+
+    Writes the access token to stdout so it can be captured, for example:
+
+        curl -H "Authorization: Bearer $(exls get-token)" https://api.exalsius.ai/...
+
+    The token is refreshed automatically if it has expired. With --format json
+    the output is {"access_token": "<token>"}; otherwise the bare token is
+    printed. Diagnostics are written to stderr and, on any failure, nothing is
+    written to stdout and the command exits non-zero.
+    """
+    bundle = _get_bundle(ctx)
+    auth_service: AuthService = bundle.get_auth_service()
+
+    try:
+        auth_session = auth_service.acquire_access_token()
+    except NotLoggedInWarning:
+        typer.echo("You are not logged in. Please log in.", err=True)
+        raise typer.Exit(1)
+    except ServiceError as e:
+        typer.echo(
+            f"Failed to acquire access token. Please log in again. Error: {str(e)}",
+            err=True,
+        )
+        raise typer.Exit(1)
+
+    access_token: str = auth_session.token.access_token
+    if bundle.object_output_format == OutputFormat.JSON:
+        typer.echo(json.dumps({"access_token": access_token}))
+    else:
+        typer.echo(access_token)

--- a/tests/unit/auth/test_app_get_token.py
+++ b/tests/unit/auth/test_app_get_token.py
@@ -1,0 +1,79 @@
+"""Unit tests for the `exls get-token` command."""
+
+import json
+from datetime import datetime, timedelta, timezone
+from unittest.mock import Mock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from exls.app import app
+from exls.auth.adapters.bundle import AuthBundle
+from exls.auth.core.domain import AuthSession, LoadedToken, User
+from exls.auth.core.service import AuthService, NotLoggedInWarning
+from exls.shared.core.exceptions import ServiceError
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def auth_session() -> AuthSession:
+    return AuthSession(
+        user=User(email="a@b.c", nickname="alice", sub="auth0|123"),
+        token=LoadedToken(
+            client_id="client-id",
+            access_token="my-access-token",
+            id_token="id-token",
+            refresh_token="refresh-token",
+            expiry=datetime.now(timezone.utc) + timedelta(hours=1),
+        ),
+    )
+
+
+@pytest.fixture
+def mock_service(auth_session: AuthSession) -> Mock:
+    service = Mock(spec=AuthService)
+    service.acquire_access_token.return_value = auth_session
+    return service
+
+
+def test_get_token_prints_raw_token_to_stdout(mock_service: Mock) -> None:
+    with patch.object(AuthBundle, "get_auth_service", return_value=mock_service):
+        result = runner.invoke(app, ["get-token"])
+
+    assert result.exit_code == 0
+    assert result.stdout == "my-access-token\n"
+
+
+def test_get_token_json_format_emits_object(mock_service: Mock) -> None:
+    with patch.object(AuthBundle, "get_auth_service", return_value=mock_service):
+        result = runner.invoke(app, ["--format", "json", "get-token"])
+
+    assert result.exit_code == 0
+    assert json.loads(result.stdout) == {"access_token": "my-access-token"}
+
+
+def test_get_token_not_logged_in_errors_to_stderr(mock_service: Mock) -> None:
+    mock_service.acquire_access_token.side_effect = NotLoggedInWarning(
+        "You are not logged in: no token"
+    )
+
+    with patch.object(AuthBundle, "get_auth_service", return_value=mock_service):
+        result = runner.invoke(app, ["get-token"])
+
+    assert result.exit_code == 1
+    assert result.stdout == ""
+    assert "not logged in" in result.stderr.lower()
+
+
+def test_get_token_service_error_errors_to_stderr(mock_service: Mock) -> None:
+    mock_service.acquire_access_token.side_effect = ServiceError(
+        message="Session is expired. Please log in again."
+    )
+
+    with patch.object(AuthBundle, "get_auth_service", return_value=mock_service):
+        result = runner.invoke(app, ["get-token"])
+
+    assert result.exit_code == 1
+    assert result.stdout == ""
+    assert "failed to acquire access token" in result.stderr.lower()


### PR DESCRIPTION
## Description

This PR adds `exls get-token`, a top-level command that prints the current access (bearer) token to stdout for use in scripts that call the exalsius API.

## Notes for Reviewers

<!-- 
## PR Title Format (Conventional Commits)

Please use one of the following prefixes in your PR title (the scope is optional):

- `feat(scope): ...` – New features or significant enhancements
- `fix(scope): ...` – Bug fixes
- `docs(scope): ...` – Documentation changes
- `refactor(scope): ...` – Code changes that neither fix bugs nor add features
- `chore(scope): ...` – Maintenance tasks, dependency updates, etc.
- `test(scope): ...` – Adding or modifying tests
- `ci(scope): ...` – Changes to CI configuration files and scripts

**Example:** `feat(auth): add OAuth2 login support`

Please also aim to use Conventional Commits for your individual commits, or squash your commits before merging.  
The **CHANGELOG is automatically generated** based on `feat:` and `fix:` messages.

## Multiple Contributors?

If this PR includes commits from multiple authors and you're going to squash-merge it, please consider adding  
`Co-authored-by:` lines to the final squash commit message to give proper credit.

Example:

```
Co-authored-by: Alice <alice@example.com>
Co-authored-by: Bob <bob@example.com>
```

More information: Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
-->